### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_easydns.py
+++ b/tests/test_octodns_provider_easydns.py
@@ -367,7 +367,9 @@ class TestEasyDnsProvider(TestCase):
         self.assertEqual(srv_invalid_content4['values'][0]['target'], '')
 
     def test_apply(self):
-        provider = EasyDnsProvider('test', 'token', 'apikey')
+        provider = EasyDnsProvider(
+            'test', 'token', 'apikey', strict_supports=False
+        )
 
         resp = Mock()
         resp.json = Mock()


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957