### PR TITLE
Anchor script/release version search

### DIFF
--- a/script/release
+++ b/script/release
@@ -20,7 +20,7 @@ fi
 # Set so that setup.py will create a public release style version number
 export OCTODNS_RELEASE=1
 
-VERSION="$(grep __VERSION__ "$ROOT/octodns_easydns/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
+VERSION="$(grep "^__VERSION__" "$ROOT/octodns_easydns/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
 
 git tag -s "v$VERSION" -m "Release $VERSION"
 git push origin "v$VERSION"


### PR DESCRIPTION
Some modules have problems now that we import octodns.__VERSION__ for
user-agent strings.

/cc https://github.com/octodns/octodns-edgedns/pull/18