### PR TITLE
Version 1.0.1 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/236601ae633d4d84a99a1947d828d60b.md
+++ b/.changelog/236601ae633d4d84a99a1947d828d60b.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/317a27b6b50c4ce5aa45e5f9ee338f41.md
+++ b/.changelog/317a27b6b50c4ce5aa45e5f9ee338f41.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/3981ea67c35748fc8411409c24ae892c.md
+++ b/.changelog/3981ea67c35748fc8411409c24ae892c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/4a48c11698544a11b8ad934d629c90c5.md
+++ b/.changelog/4a48c11698544a11b8ad934d629c90c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/e0477cefcfe945098a3c021af6d0d599.md
+++ b/.changelog/e0477cefcfe945098a3c021af6d0d599.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/e4451d6b922a4e79b3fa20f6f0b1d4c2.md
+++ b/.changelog/e4451d6b922a4e79b3fa20f6f0b1d4c2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ebfb548ce3a04f2394596319b04110cb.md
+++ b/.changelog/ebfb548ce3a04f2394596319b04110cb.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/fd1f40bd1e354127958a6a04fbb72ecc.md
+++ b/.changelog/fd1f40bd1e354127958a6a04fbb72ecc.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2026-04-03
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#42](https://github.com/octodns/octodns-easydns/pull/42)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_easydns/__init__.py
+++ b/octodns_easydns/__init__.py
@@ -15,7 +15,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 class EasyDnsClientException(ProviderException):


### PR DESCRIPTION
## 1.0.1 - 2026-04-03

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#42](https://github.com/octodns/octodns-easydns/pull/42)

